### PR TITLE
Use the "Modern CMake" export model to ensure that DNCP can be easily consumed by the modern CMake dependency models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@ cmake_minimum_required(VERSION 3.6.2)
 set(CMAKE_INSTALL_PREFIX ./)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+# add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@ cmake_minimum_required(VERSION 3.6.2)
 set(CMAKE_INSTALL_PREFIX ./)
 
 add_subdirectory(src)
-# add_subdirectory(tests)
+add_subdirectory(tests)

--- a/dncp.proj
+++ b/dncp.proj
@@ -22,7 +22,7 @@
     </Target>
 
     <Target Name="Restore">
-        <Exec Command="cmake -S $(RepoDir) -B $(ArtifactsDir)" />
+        <Exec Command="cmake -S $(RepoDir) -B $(ArtifactsDir) -DCMAKE_BUILD_TYPE=$(Configuration)" />
     </Target>
 
     <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,11 @@ The recommended way to use DNCP is via [git submodules][git_submodules] and CMak
 
 The [`dncp.h`](./src/inc/dncp.h) header contains consistent definitions of common COM APIs. All data types are identically named to those in official Windows' headers. All functions are prefixed with `PAL_` followed by the official Win32 name (for example, `SysAllocString` is `PAL_SysAllocString`). Ideally, all functions provided by DNCP replace the corresponding Win32 APIs as DNCP will forward to the Windows implementation when running on Windows &ndash; see [`windows.c`](./src/windows.c).
 
-Users can set defines during compilation to tailor how they would like to develop their COM library.
+The following defines are set when referencing the `dncp::winhdrs` target:
 
 * `DNCP_TYPEDEFS` &ndash; Defines the most common Win32 data types needed for .NET scenarios. If this isn't set, the project should define them or include the official Windows' headers.
 
-* `DNCP_WINHDRS` &ndash; Includes the minimal mocked out Windows' headers provided by DNCP. This is typically needed if building on non-Windows and/or referencing official .NET headers (for example, [`cor.h`](https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cor.h)). If this is set, the project should also link against `dncp_winhdrs`, see example below.
+* `DNCP_WINHDRS` &ndash; Includes the minimal mocked out Windows' headers provided by DNCP. This is typically needed if building on non-Windows and/or referencing official .NET headers (for example, [`cor.h`](https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cor.h)).
 
 ### Walkthrough
 
@@ -36,9 +36,14 @@ These steps are the general process. Note that depending on how complex your pro
 1. Add DNCP as a submodule to your repository.
     - `git submodule add https://github.com/AaronRobinsonMSFT/DNCP.git`
 
-1. Add a reference to the DNCP directory in a CMake build file.
+1. Include in your build with CMake's [`FetchContent` module](https://cmake.org/cmake/help/latest/module/FetchContent.html).
     ```cmake
-    add_subdirectory(DNCP/)
+        include(FetchContent)
+        FetchContent_Declare(
+            dncp
+            SOURCE_DIR DNCP
+        )
+        FetchContent_MakeAvailable(dncp)
     ```
 
 1. Reference the `dncp.h` header and link the DNCP static library into the target project.
@@ -47,17 +52,12 @@ These steps are the general process. Note that depending on how complex your pro
     ```
 
     ```cmake
-    target_link_libraries(mycomlib dncp)
+    target_link_libraries(mycomlib dncp::dncp)
     ```
 
-1. For non-Windows build or if you are trying to avoid referencing any Windows header files, the following defines should be set.
+1. For non-Windows build or if you are trying to avoid referencing any Windows header files, link to the `dncp::winhdrs` target as well.
     ```cmake
-    add_compile_definitions(
-        DNCP_TYPEDEFS
-        DNCP_WINHDRS
-    )
-
-    target_link_libraries(mycomlib dncp_winhdrs)
+    target_link_libraries(mycomlib dncp::winhdrs)
     ```
 
 An example of consumption can be found in the [scenario test project](./tests/scenario/comserver/CMakeLists.txt).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,10 +13,6 @@ else()
     memory.c
     strings.c
   )
-  add_compile_definitions(
-    DNCP_TYPEDEFS
-    DNCP_WINHDRS
-  )
 endif()
 
 set(HEADERS
@@ -38,15 +34,15 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
   $<INSTALL_INTERFACE:include>)
 
+# Chain in the Windows headers interface
+add_subdirectory(inc/winhdrs)
+
 if(NOT WIN32)
   # Marked private because consumption of the Windows' headers is
   # a build implementation detail and shouldn't impose on the consumer
   # of dncp.
-  target_include_directories(dncp PRIVATE ./inc/winhdrs)
+  target_link_libraries(dncp PRIVATE dncp::winhdrs)
 endif()
-
-# Chain in the Windows headers interface
-add_subdirectory(inc/winhdrs)
 
 install(TARGETS dncp EXPORT dncp
   PUBLIC_HEADER DESTINATION include

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,11 @@ add_library(dncp
 add_library(dncp::dncp ALIAS dncp)
 
 set_target_properties(dncp PROPERTIES PUBLIC_HEADER inc/dncp.h)
-target_include_directories(dncp PRIVATE ./inc)
+target_include_directories(
+  dncp
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  $<INSTALL_INTERFACE:include>)
 
 if(NOT WIN32)
   # Marked private because consumption of the Windows' headers is

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,8 +29,10 @@ add_library(dncp
   ${HEADERS}
 )
 
+add_library(dncp::dncp ALIAS dncp)
+
 set_target_properties(dncp PROPERTIES PUBLIC_HEADER inc/dncp.h)
-target_include_directories(dncp PUBLIC ./inc)
+target_include_directories(dncp PRIVATE ./inc)
 
 if(NOT WIN32)
   # Marked private because consumption of the Windows' headers is
@@ -39,7 +41,25 @@ if(NOT WIN32)
   target_include_directories(dncp PRIVATE ./inc/winhdrs)
 endif()
 
-install(TARGETS dncp)
-
 # Chain in the Windows headers interface
 add_subdirectory(inc/winhdrs)
+
+install(TARGETS dncp EXPORT dncp
+  PUBLIC_HEADER DESTINATION include
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(EXPORT dncp NAMESPACE dncp:: FILE dncplib.cmake DESTINATION lib/cmake/dncp)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/dncp-config.cmake
+  INSTALL_DESTINATION lib/cmake/dncp)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/dncp-config-version.cmake
+  VERSION 1.0.0
+  COMPATIBILITY SameMajorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dncp-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/dncp-config-version.cmake
+        DESTINATION lib/cmake/dncp)

--- a/src/config.cmake.in
+++ b/src/config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/winhdrs.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/dncplib.cmake")
+
+check_required_components(dncp)

--- a/src/inc/winhdrs/CMakeLists.txt
+++ b/src/inc/winhdrs/CMakeLists.txt
@@ -13,8 +13,9 @@ set(WINHDRS_HEADERS
     unknwn.h
     winerror.h)
 
-add_library(dncp_winhdrs INTERFACE)
-target_include_directories(dncp_winhdrs INTERFACE
+add_library(winhdrs INTERFACE)
+add_library(dncp::winhdrs ALIAS winhdrs)
+target_include_directories(winhdrs INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/winhdrs>
 )
@@ -22,3 +23,7 @@ target_include_directories(dncp_winhdrs INTERFACE
 install(FILES ${WINHDRS_HEADERS}
   DESTINATION include/winhdrs
 )
+
+install(TARGETS winhdrs EXPORT winhdrs INCLUDES DESTINATION include/winhdrs)
+
+install(EXPORT winhdrs NAMESPACE dncp:: FILE winhdrs.cmake DESTINATION lib/cmake/dncp)

--- a/src/inc/winhdrs/CMakeLists.txt
+++ b/src/inc/winhdrs/CMakeLists.txt
@@ -20,6 +20,10 @@ target_include_directories(winhdrs INTERFACE
   $<INSTALL_INTERFACE:include/winhdrs>
 )
 
+target_compile_definitions(winhdrs INTERFACE
+  DNCP_TYPEDEFS
+  DNCP_WINHDRS)
+
 install(FILES ${WINHDRS_HEADERS}
   DESTINATION include/winhdrs
 )

--- a/tests/scenario/comserver/CMakeLists.txt
+++ b/tests/scenario/comserver/CMakeLists.txt
@@ -17,10 +17,10 @@ if(NOT WIN32)
   )
 
   # Include the exported headers for non-Windows building.
-  target_link_libraries(comserver dncp_winhdrs)
+  target_link_libraries(comserver dncp::winhdrs)
 endif()
 
-target_link_libraries(comserver dncp)
+target_link_libraries(comserver dncp::dncp)
 install(TARGETS comserver
   DESTINATION bin
 )

--- a/tests/scenario/comserver/CMakeLists.txt
+++ b/tests/scenario/comserver/CMakeLists.txt
@@ -11,11 +11,6 @@ add_library(comserver
 )
 
 if(NOT WIN32)
-  add_compile_definitions(
-    DNCP_TYPEDEFS
-    DNCP_WINHDRS
-  )
-
   # Include the exported headers for non-Windows building.
   target_link_libraries(comserver dncp::winhdrs)
 endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,8 +16,8 @@ if(NOT WIN32)
   )
 
   # Include the exported headers for non-Windows building.
-  target_link_libraries(dncp_test dncp_winhdrs)
+  target_link_libraries(dncp_test dncp::winhdrs)
 endif()
 
-target_link_libraries(dncp_test dncp)
+target_link_libraries(dncp_test dncp::dncp)
 install(TARGETS dncp_test)


### PR DESCRIPTION
This ensures that people can consume dncp through any of the following CMake models:

- separate build + `find_package`
- `ExternalProject`
- `FetchContent`

This should also make it trivial to produce a vcpkg portfile for DNCP to make it installable with `vcpkg install`.

I've validated locally that DNMD can be easily updated to build with this new model (and after this PR can follow-up with a PR to DNMD to make the same changes there).