### PR TITLE
Add const modifiers to some methods to make them usable from `const` contexts.

### DIFF
--- a/src/inc/dncp.h
+++ b/src/inc/dncp.h
@@ -485,11 +485,11 @@ HRESULT PAL_IIDFromString(LPCOLESTR, IID*);
                 return (*this);
             }
 
-            operator T*() { return p; }
+            operator T*() const { return p; }
 
-            T** operator&() { return &p; }
+            T** operator&() const { return &p; }
 
-            T* operator->() { return p; }
+            T* operator->() const { return p; }
 
             void Attach(T* t) noexcept
             {


### PR DESCRIPTION
This will allow us to make some small improvements/cleanup to AaronRobinsonMSFT/DNMD#39