### PR TITLE
Enable POSITION_INDEPENDENT_CODE on dncp static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,9 @@ add_library(dncp
 
 add_library(dncp::dncp ALIAS dncp)
 
-set_target_properties(dncp PROPERTIES PUBLIC_HEADER inc/dncp.h)
+set_target_properties(dncp PROPERTIES
+  PUBLIC_HEADER inc/dncp.h
+  POSITION_INDEPENDENT_CODE ON)
 target_include_directories(
   dncp
   PUBLIC


### PR DESCRIPTION
The dncp static library is linked into shared libraries (e.g. the comserver test scenario). On Linux x64 this requires `-fPIC`, otherwise the linker fails with:

```
relocation R_X86_64_PC32 against symbol 'PAL_SysAllocStringLen' can not be used when making a shared object; recompile with -fPIC
```

Setting `POSITION_INDEPENDENT_CODE ON` on the target lets CMake add `-fPIC` on platforms that need it, and is a no-op elsewhere (e.g. Windows, macOS).